### PR TITLE
Left click outside bug fix

### DIFF
--- a/src/contextMenu.component.ts
+++ b/src/contextMenu.component.ts
@@ -80,7 +80,15 @@ export class ContextMenuComponent implements AfterContentInit {
   }
 
   @HostListener('document:click')
+  public leftClickOutside(): void{
+    this.clickedOutside();
+  }
+
   @HostListener('document:contextmenu')
+  public rightClickOutside(): void{
+    this.clickedOutside();
+  }
+
   public clickedOutside(): void {
     if (!this.isOpening) {
       this.hideMenu();


### PR DESCRIPTION
Clicking outside the context menu when using @angular/core: 2.3.0 was not closing the context menu.