### PR TITLE
Add dropdown-divider on dividers when using Bootstrap 4

### DIFF
--- a/src/contextMenu.component.ts
+++ b/src/contextMenu.component.ts
@@ -35,8 +35,9 @@ export interface ILinkConfig {
             innerHTML="{{link.html ? link.html(item) : ''}}"></a>
         </li>
         <!-- Declarative context menu -->
-        <li *ngFor="let menuItem of visibleMenuItems" [class.disabled]="!isMenuItemEnabled(menuItem)"
-          [attr.role]="menuItem.divider ? 'separator' : undefined" [class.divider]="menuItem.divider">
+        <li *ngFor="let menuItem of visibleMenuItems" [class.disabled]="!isMenuItemEnabled(menuItem)" 
+            [class.divider]="menuItem.divider" [class.dropdown-divider]="useBootstrap4 && menuItem.divider"
+            [attr.role]="menuItem.divider ? 'separator' : undefined">
           <a *ngIf="!menuItem.divider" href [class.dropdown-item]="useBootstrap4"
             [class.disabled]="useBootstrap4 && !isMenuItemEnabled(menuItem)"
             (click)="menuItem.triggerExecute(item, $event); $event.preventDefault(); $event.stopPropagation();">


### PR DESCRIPTION
When using Bootstrap 4 (i.e. useBootstrap4 is true), add the Bootstrap 4 dropdown-divider CSS class to context menu divider items.